### PR TITLE
Adjust for newer VSD, fix script errors

### DIFF
--- a/openssl/make_certs.sh
+++ b/openssl/make_certs.sh
@@ -56,7 +56,7 @@ $OPENSSL req \
 # rootkey.pem is used only to create root certificate
 
 EXITCODE="$?"
-if [ ! "$EXITCODE" == 0 ]; then
+if [ $EXITCODE -ne 0 ]; then
   echo "Error $EXITCODE at line $LINENO"
   exit 1
 fi
@@ -75,7 +75,7 @@ $OPENSSL x509 \
 # rootkey.pem goes into root.pem
 # rootcert.pem goes into root.pem, serverCA.pem, and server.pem
 EXITCODE="$?"
-if [ ! "$EXITCODE" == 0 ]; then
+if [ $EXITCODE -ne 0 ]; then
   echo "Error $EXITCODE at line $LINENO"
   exit 1
 fi
@@ -108,7 +108,7 @@ $OPENSSL req \
 # serverCAreq.pem is used only to create serverCAcert.pem
 
 EXITCODE="$?"
-if [ ! "$EXITCODE" == 0 ]; then
+if [ $EXITCODE -ne 0 ]; then
   echo "Error $EXITCODE at line $LINENO"
   exit 1
 fi
@@ -129,7 +129,7 @@ $OPENSSL x509 \
 # serverCAcert.pem goes into serverCA.pem and server.pem
 
 EXITCODE="$?"
-if [ ! "$EXITCODE" == 0 ]; then
+if [ $EXITCODE -ne 0 ]; then
   echo "Error $EXITCODE at line $LINENO"
   exit 1
 fi
@@ -167,7 +167,7 @@ $OPENSSL req \
 # serverreq.pem is used only to create servercert.pem
 
 EXITCODE="$?"
-if [ ! "$EXITCODE" == 0 ]; then
+if [ $EXITCODE -ne 0 ]; then
   echo "Error $EXITCODE at line $LINENO"
   exit 1
 fi
@@ -188,7 +188,7 @@ $OPENSSL x509 \
 # servercert.pem is used to create server.pem
 
 EXITCODE="$?"
-if [ ! "$EXITCODE" == 0 ]; then
+if [ $EXITCODE -ne 0 ]; then
   echo "Error $EXITCODE at line $LINENO"
   exit 1
 fi

--- a/src/StatStatistic.gs
+++ b/src/StatStatistic.gs
@@ -55,17 +55,16 @@ classmethod: StatStatistic
 _stats
 
 	| gsFile stream line stats string i |
-	gsFile := GsFile openReadOnServer: '$GEMSTONE/bin/vsd'.
+	gsFile := GsFile openReadOnServer: '$GEMSTONE/bin/vsd.stats.tcl'.
 	[
 		[
 			line := gsFile nextLine.
-			line notNil and: [line ~= 'array set statDocs {
-'].
-		] whileTrue: [].
+			line isNil or: [line includesString: 'array set statDocs' ].
+		] whileFalse: [].
 		stream := WriteStream on: String new.
 		[
-			(line := gsFile nextLine) = 'array set vsdhelp {
-'.
+			line := gsFile nextLine.
+			line isNil
 		] whileFalse: [
 			stream nextPutAll: line.
 		].
@@ -86,13 +85,12 @@ _stats
 		string := string collect: [:each | each = $\ ifTrue: [Character lf] ifFalse: [each]].
 		array at: 1 put: string.
 	].
-	1 to: 47 do: [:i | 
-		stats at: 'SessionStat' 		, i printString put: (stats at: 'SessionStat0'	) copy.
-		stats at: 'VMStat' 			, i printString put: (stats at: 'VMStat0'		) copy.
-		stats at: 'GlobalStat' 		, i printString put: (stats at: 'GlobalStat0'		) copy.
+	1 to: 47 do: [:j| 
+		stats at: 'SessionStat' 		, j printString put: (stats at: 'SessionStat0'	) copy.
+		stats at: 'GlobalStat' 		, j printString put: (stats at: 'GlobalStat0'		) copy.
 	].
-	0 to: 10 do: [:i | 
-		stats at: 'sharedCounter' 	, i printString put: (stats at: 'sharedCounter'	) copy.
+	0 to: 10 do: [:j | 
+		stats at: 'sharedCounter' 	, j printString put: (stats at: 'sharedCounter'	) copy.
 	].
 	[
 		stream atEnd or: [(line := stream nextLine) = 'array set statDefinitions {'].
@@ -106,11 +104,11 @@ _stats
 			at: (stream upTo: $})
 			ifAbsentPut: [#('' nil nil nil nil) copy].
 		values := ReadStream on: (stream upTo: ${; upTo: $}).
-		2 to: 5 do: [:i | 
+		2 to: 5 do: [:j | 
 			string := values upTo: ((values peekFor: $")
 				ifTrue: [$"]
 				ifFalse: [$ ]).
-			array at: i put: string asSymbol.
+			array at: j put: string asSymbol.
 		].
 	].
 	stats do: [:each | 


### PR DESCRIPTION
Fix errors in make_certs.sh
Adjust code to load stat descriptions from newer versions of VSD.
non-SSL server now runs on 3.4.x /  3.5.x
SSL version has issues not yet resolved.
